### PR TITLE
'agora tunnel create' and related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- FEATURE: New `agora tunnel create` command provisions a durable tunnel resource (direct or proxy, via `--backend`) without serving it, and `agora tunnel serve <name>` now serves an already-created proxy tunnel with `--mode`/`--backend` optional.
+
 ## v0.1.4
 
 - FEATURE: New unauthenticated `GET /v1/version` API endpoint for interrogating the controller's build version.

--- a/cmd/agora/tunnel.go
+++ b/cmd/agora/tunnel.go
@@ -254,6 +254,32 @@ func ensureTunnelCreatedOrReused(client *api.Client, req *api.CreateTunnelReques
 	}
 }
 
+// resolveServePlan decides the mode and backend to serve with, given the named
+// tunnel (nil when it does not yet exist) and the command flags. When the tunnel
+// is absent it must be created, so --mode and --backend are required; when it
+// already exists its stored mode/backend are used (and any provided flags must
+// match). Direct tunnels cannot be served by the CLI runtime.
+func resolveServePlan(existing *api.Tunnel, flagMode, flagBackend string) (mode, backend string, create bool, err error) {
+	if existing == nil {
+		if flagMode == "" || flagBackend == "" {
+			return "", "", false, fmt.Errorf("tunnel does not exist; --mode and --backend are required to create it")
+		}
+		return flagMode, flagBackend, true, nil
+	}
+	if existing.Kind != api.TunnelKindProxy {
+		return "", "", false, fmt.Errorf("tunnel '%s' is direct; serve it from your application via tunnel.Listen", existing.Name)
+	}
+	effMode := string(existing.Mode)
+	effBackend := existing.BackendTarget.Or("")
+	if flagMode != "" && flagMode != effMode {
+		return "", "", false, fmt.Errorf("tunnel '%s' has mode '%s'; omit --mode or pass --mode %s", existing.Name, effMode, effMode)
+	}
+	if flagBackend != "" && flagBackend != effBackend {
+		return "", "", false, fmt.Errorf("tunnel '%s' has backend '%s'; omit --backend or pass the matching value", existing.Name, effBackend)
+	}
+	return effMode, effBackend, false, nil
+}
+
 func findGrantByEmail(grants *api.ListTunnelGrantsResponse, email string) *api.TunnelGrant {
 	for _, grant := range *grants {
 		if strings.EqualFold(grant.Email, email) {

--- a/cmd/agora/tunnelCreate.go
+++ b/cmd/agora/tunnelCreate.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openziti/agora/internal/api"
+	"github.com/openziti/agora/internal/clioutput"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	tunnelCmd.AddCommand(newTunnelCreateCommand().cmd)
+}
+
+type tunnelCreateCommand struct {
+	mode        string
+	backend     string
+	grantEmails []string
+	jsonOutput  bool
+	cmd         *cobra.Command
+}
+
+func newTunnelCreateCommand() *tunnelCreateCommand {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a tunnel resource without serving it",
+		Long: "Create a durable tunnel resource without serving or connecting to it. " +
+			"Omit --backend to create a direct tunnel (served by an application via the SDK); " +
+			"pass --backend to create a proxy tunnel that 'agora tunnel serve' can run later.",
+		Args: cobra.ExactArgs(1),
+	}
+	command := &tunnelCreateCommand{cmd: cmd}
+	cmd.Flags().StringVar(&command.mode, "mode", "", "Tunnel mode: http, tcp, or udp")
+	cmd.Flags().StringVar(&command.backend, "backend", "", "Backend target; when set the tunnel is a proxy tunnel, otherwise it is direct")
+	cmd.Flags().StringSliceVar(&command.grantEmails, "grant", nil, "Grant access to an account email (repeatable)")
+	cmd.Flags().BoolVar(&command.jsonOutput, "json", false, "Output the raw tunnel resource as JSON")
+	panicIfErr(cmd.MarkFlagRequired("mode"))
+	cmd.RunE = command.runE
+	return command
+}
+
+func (cmd *tunnelCreateCommand) runE(_ *cobra.Command, args []string) (err error) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+		if panicInstead {
+			panic(recovered)
+		}
+		switch typed := recovered.(type) {
+		case error:
+			err = typed
+		default:
+			err = fmt.Errorf("%v", typed)
+		}
+	}()
+
+	cmd.run(args)
+	return nil
+}
+
+func (cmd *tunnelCreateCommand) run(args []string) {
+	panicIfUnsupportedMode(cmd.mode)
+	mode := api.TunnelMode(cmd.mode)
+
+	root := requireEnabledRoot()
+	env := root.Environment()
+	client := openEnvironmentAPIClient(root)
+
+	req := &api.CreateTunnelRequest{
+		EnvironmentId: env.EnvironmentID,
+		Name:          args[0],
+		Mode:          mode,
+		GrantEmails:   cmd.grantEmails,
+	}
+	if cmd.backend != "" {
+		panicIfErr(validateModeAndTarget(mode, cmd.backend))
+		req.BackendTarget = api.NewOptString(cmd.backend)
+	}
+
+	res, err := client.CreateTunnel(context.Background(), req)
+	panicIfErr(err)
+	tunnel, err := tunnelFromCreateResult(res)
+	panicIfErr(err)
+
+	if cmd.jsonOutput {
+		panicIfErr(clioutput.RenderJSON(tunnel))
+		return
+	}
+
+	fmt.Printf(
+		"created tunnel '%s' id='%s' mode='%s' kind='%s' backend='%s'\n",
+		tunnel.Name,
+		tunnel.ID,
+		tunnel.Mode,
+		tunnel.Kind,
+		formatTunnelBackend(*tunnel),
+	)
+}
+
+// tunnelFromCreateResult maps a create tunnel response variant to the created
+// tunnel or a descriptive error. Unlike the serve path it does not reuse an
+// existing tunnel: a name conflict is surfaced as an error.
+func tunnelFromCreateResult(res api.CreateTunnelRes) (*api.Tunnel, error) {
+	switch typed := res.(type) {
+	case *api.Tunnel:
+		return typed, nil
+	case *api.CreateTunnelConflict:
+		return nil, fmt.Errorf("create tunnel failed: %s", typed.Message)
+	case *api.CreateTunnelNotFound:
+		return nil, fmt.Errorf("create tunnel failed: %s", typed.Message)
+	case *api.CreateTunnelUnauthorized:
+		return nil, fmt.Errorf("create tunnel failed: %s", typed.Message)
+	case *api.CreateTunnelInternalServerError:
+		return nil, fmt.Errorf("create tunnel failed: %s", typed.Message)
+	default:
+		return nil, fmt.Errorf("unexpected create tunnel response: %T", res)
+	}
+}

--- a/cmd/agora/tunnelCreate_test.go
+++ b/cmd/agora/tunnelCreate_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openziti/agora/internal/api"
+)
+
+func TestTunnelFromCreateResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success returns tunnel", func(t *testing.T) {
+		want := &api.Tunnel{ID: "tt_abcdef012345", Name: "gw"}
+		got, err := tunnelFromCreateResult(want)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != want {
+			t.Fatalf("expected tunnel %v, got %v", want, got)
+		}
+	})
+
+	t.Run("conflict surfaces server message", func(t *testing.T) {
+		_, err := tunnelFromCreateResult(&api.CreateTunnelConflict{Code: "conflict", Message: "tunnel name already exists"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "tunnel name already exists") {
+			t.Fatalf("unexpected error message: %q", err.Error())
+		}
+	})
+
+	t.Run("not found errors", func(t *testing.T) {
+		_, err := tunnelFromCreateResult(&api.CreateTunnelNotFound{Code: "not_found", Message: "environment not found"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("unauthorized errors", func(t *testing.T) {
+		_, err := tunnelFromCreateResult(&api.CreateTunnelUnauthorized{Code: "unauthorized", Message: "unauthorized"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("internal server error errors", func(t *testing.T) {
+		_, err := tunnelFromCreateResult(&api.CreateTunnelInternalServerError{Code: "internal_error", Message: "boom"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/cmd/agora/tunnelServe.go
+++ b/cmd/agora/tunnelServe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openziti/agora/environment/env_core"
 	"github.com/openziti/agora/internal/api"
 	"github.com/openziti/agora/sdk/agent/networkpb"
 	"github.com/spf13/cobra"
@@ -28,12 +29,10 @@ func newTunnelServeCommand() *tunnelServeCommand {
 		Args:  cobra.ExactArgs(1),
 	}
 	command := &tunnelServeCommand{cmd: cmd}
-	cmd.Flags().StringVar(&command.mode, "mode", "", "Tunnel mode: http, tcp, or udp")
-	cmd.Flags().StringVar(&command.backend, "backend", "", "Backend target for the local provider")
+	cmd.Flags().StringVar(&command.mode, "mode", "", "Tunnel mode: http, tcp, or udp (required when creating a new tunnel)")
+	cmd.Flags().StringVar(&command.backend, "backend", "", "Backend target for the local provider (required when creating a new tunnel)")
 	cmd.Flags().BoolVar(&command.foreground, "foreground", false, "Run the tunnel runtime directly instead of using the local network agent")
 	cmd.Flags().StringSliceVar(&command.grantEmails, "grant", nil, "Grant access to an account email (repeatable)")
-	panicIfErr(cmd.MarkFlagRequired("mode"))
-	panicIfErr(cmd.MarkFlagRequired("backend"))
 	cmd.RunE = command.runE
 	return command
 }
@@ -60,23 +59,38 @@ func (cmd *tunnelServeCommand) runE(_ *cobra.Command, args []string) (err error)
 }
 
 func (cmd *tunnelServeCommand) run(args []string) {
-	panicIfUnsupportedMode(cmd.mode)
-	mode := api.TunnelMode(cmd.mode)
-	panicIfErr(validateModeAndTarget(mode, cmd.backend))
+	name := args[0]
+	root := requireEnabledRoot()
+	client := openEnvironmentAPIClient(root)
+
+	existing := resolveTunnelByName(client, name, api.ListTunnelsScopeAll)
+	mode, backend, create, err := resolveServePlan(existing, cmd.mode, cmd.backend)
+	panicIfErr(err)
+	panicIfUnsupportedMode(mode)
+	panicIfErr(validateModeAndTarget(api.TunnelMode(mode), backend))
 
 	if cmd.foreground {
-		cmd.runForeground(args)
+		tunnel := existing
+		if create {
+			tunnel = ensureTunnelCreatedOrReused(client, &api.CreateTunnelRequest{
+				EnvironmentId: root.Environment().EnvironmentID,
+				Name:          name,
+				Mode:          api.TunnelMode(mode),
+				BackendTarget: api.NewOptString(backend),
+				GrantEmails:   cmd.grantEmails,
+			}, root.Environment().EnvironmentID)
+		}
+		cmd.runForeground(root, client, tunnel)
 		return
 	}
 
-	root := requireEnabledRoot()
-	client, cleanup := requireRunningNetworkClient(root)
+	netClient, cleanup := requireRunningNetworkClient(root)
 	defer cleanup()
 
-	res, err := client.EnsureServe(context.Background(), &networkpb.EnsureServeRequest{
-		Name:          args[0],
-		Mode:          cmd.mode,
-		BackendTarget: cmd.backend,
+	res, err := netClient.EnsureServe(context.Background(), &networkpb.EnsureServeRequest{
+		Name:          name,
+		Mode:          mode,
+		BackendTarget: backend,
 		GrantEmails:   append([]string(nil), cmd.grantEmails...),
 	})
 	panicIfErr(err)
@@ -90,19 +104,8 @@ func (cmd *tunnelServeCommand) run(args []string) {
 	)
 }
 
-func (cmd *tunnelServeCommand) runForeground(args []string) {
-	mode := api.TunnelMode(cmd.mode)
-	root := requireEnabledRoot()
+func (cmd *tunnelServeCommand) runForeground(root env_core.Root, client *api.Client, tunnel *api.Tunnel) {
 	env := root.Environment()
-	client := openEnvironmentAPIClient(root)
-
-	tunnel := ensureTunnelCreatedOrReused(client, &api.CreateTunnelRequest{
-		EnvironmentId: env.EnvironmentID,
-		Name:          args[0],
-		Mode:          mode,
-		BackendTarget: api.NewOptString(cmd.backend),
-		GrantEmails:   cmd.grantEmails,
-	}, env.EnvironmentID)
 	for _, email := range cmd.grantEmails {
 		ignoreConflictGrantAdd(client, tunnel.ID, email)
 	}

--- a/cmd/agora/tunnelServe_test.go
+++ b/cmd/agora/tunnelServe_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openziti/agora/internal/api"
+)
+
+func TestResolveServePlan(t *testing.T) {
+	t.Parallel()
+
+	proxy := func() *api.Tunnel {
+		return &api.Tunnel{
+			Name:          "pgw",
+			Kind:          api.TunnelKindProxy,
+			Mode:          api.TunnelModeHTTP,
+			BackendTarget: api.NewOptString("http://127.0.0.1:8080"),
+		}
+	}
+
+	t.Run("missing tunnel requires mode and backend", func(t *testing.T) {
+		mode, backend, create, err := resolveServePlan(nil, "http", "http://127.0.0.1:8080")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !create || mode != "http" || backend != "http://127.0.0.1:8080" {
+			t.Fatalf("unexpected plan: mode=%q backend=%q create=%v", mode, backend, create)
+		}
+	})
+
+	t.Run("missing tunnel without mode errors", func(t *testing.T) {
+		if _, _, _, err := resolveServePlan(nil, "", "http://127.0.0.1:8080"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("missing tunnel without backend errors", func(t *testing.T) {
+		if _, _, _, err := resolveServePlan(nil, "http", ""); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("existing proxy reused without flags", func(t *testing.T) {
+		mode, backend, create, err := resolveServePlan(proxy(), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if create {
+			t.Fatal("expected create=false for existing tunnel")
+		}
+		if mode != "http" || backend != "http://127.0.0.1:8080" {
+			t.Fatalf("unexpected plan: mode=%q backend=%q", mode, backend)
+		}
+	})
+
+	t.Run("direct tunnel rejected", func(t *testing.T) {
+		direct := &api.Tunnel{Name: "gw", Kind: api.TunnelKindDirect, Mode: api.TunnelModeHTTP}
+		_, _, _, err := resolveServePlan(direct, "", "")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "direct") {
+			t.Fatalf("unexpected error message: %q", err.Error())
+		}
+	})
+
+	t.Run("mode mismatch errors", func(t *testing.T) {
+		if _, _, _, err := resolveServePlan(proxy(), "tcp", ""); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("backend mismatch errors", func(t *testing.T) {
+		if _, _, _, err := resolveServePlan(proxy(), "", "http://other:9090"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("matching flags accepted", func(t *testing.T) {
+		if _, _, _, err := resolveServePlan(proxy(), "http", "http://127.0.0.1:8080"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/docs/current/layer-1/agent.md
+++ b/docs/current/layer-1/agent.md
@@ -215,7 +215,8 @@ Current command behavior is:
 
 - `agora enable`: controller-direct plus local-root mutation, then best-effort runtime reload
 - `agora disable`: asks the runtime to stop managed activity and clear desired state, then disables the controller-side environment and removes local state
-- `agora tunnel serve`: delegates to the runtime by default, with `--foreground` as a debug bypass
+- `agora tunnel create <name> --mode <mode> [--backend <target>]`: controller-direct creation of a durable tunnel resource without serving it. Omitting `--backend` creates a direct tunnel (served by an application via the SDK `tunnel.Listen`); supplying `--backend` creates a proxy tunnel that `agora tunnel serve` can run later. Fails on name conflict (does not reuse)
+- `agora tunnel serve <name>`: delegates to the runtime by default, with `--foreground` as a debug bypass. When `<name>` already exists as a proxy tunnel its stored mode/backend are reused and `--mode`/`--backend` are optional; otherwise both are required and the tunnel is created and served in one step. Serving a direct tunnel is rejected (those are served by the owning application via `tunnel.Listen`)
 - `agora tunnel connect`: delegates to the runtime by default, with `--foreground` as a debug bypass
 - `agora tunnel delete <name|tt_...>`: coordinates with the runtime before removing controller-side resources
 - `agora tunnel delete serve <name|tt_...>`: removes managed provider-side desired state and stops it if live

--- a/docs/current/layer-1/spec.md
+++ b/docs/current/layer-1/spec.md
@@ -65,20 +65,25 @@ Supported tunnel modes in the current Layer 1 surface are:
 
 The user-facing verbs are:
 
+- `create`: provision a durable tunnel resource without serving or connecting
 - `serve`: provider-side runtime ownership
 - `connect`: consumer-side runtime ownership
+
+`agora tunnel create <name>` provisions a durable tunnel resource and its fabric policy without serving or connecting to it. Omitting `--backend` creates a direct tunnel; supplying `--backend` creates a proxy tunnel. Creation fails on a name conflict rather than reusing an existing tunnel.
 
 By default, `agora tunnel serve` and `agora tunnel connect` delegate to the local `agora network` runtime. Both commands support `--foreground` as a debug bypass that runs the runtime directly in the CLI process and does not alter agent-managed desired state.
 
 Proxy tunnels are the managed runtime shape. They require a backend target,
 create tunnel serve records when hosted, and are the shape used by
-`agora tunnel serve` and `tunnel.EnsureServed`.
+`agora tunnel serve` and `tunnel.EnsureServed`. `agora tunnel serve` creates the
+proxy tunnel from `--mode`/`--backend` when it does not yet exist, or serves an
+already-created proxy tunnel (with those flags optional).
 
 Direct tunnels are the SDK-native provider shape. They have no backend
 target because the embedding process serves the overlay listener itself.
-They are provisioned explicitly through `sdk/agent/tunnel.Create`, listened
-through `sdk/agent/tunnel.Listen`, and deleted through
-`sdk/agent/tunnel.Delete`. `Listen` returns a raw `net.Listener` and does
+They are provisioned through `agora tunnel create` (without `--backend`) or
+`sdk/agent/tunnel.Create`, listened through `sdk/agent/tunnel.Listen`, and
+deleted through `agora tunnel delete` or `sdk/agent/tunnel.Delete`. `Listen` returns a raw `net.Listener` and does
 not create a tunnel serve record or heartbeat. Direct tunnels currently
 support stream modes (`http` and `tcp`) for listening; packet-shaped direct
 UDP is deferred.

--- a/docs/current/layer-1/status.md
+++ b/docs/current/layer-1/status.md
@@ -28,6 +28,7 @@ Implemented Layer 1 behavior includes:
 - agent-backed `serve` and `connect` by default, with `--foreground` direct-runtime bypass for debugging
 - SDK-native direct provider tunnels through `tunnel.Create`, `tunnel.Listen`, and `tunnel.Delete`, returning a raw `net.Listener` without the managed runtime
 - SDK-native direct consumer dialers through `tunnel.Attach`, `tunnel.Detach`, and `tunnel.Dial`, returning a raw `net.Conn` without a managed connect actor or local proxy port
+- standalone `agora tunnel create` for provisioning durable tunnel resources (direct or proxy) without serving, and `agora tunnel serve` reuse of an already-created proxy tunnel
 - unified tunnel delete semantics for both durable tunnel resources and managed runtime state
 - composite `agora status` covering local root state, local agent state, controller environment state, owned tunnels, active serve details, and attachment counts
 - meaningful provider-side and consumer-side request/session logging


### PR DESCRIPTION
- FEATURE: New `agora tunnel create` command provisions a durable tunnel resource (direct or proxy, via `--backend`) without serving it, and `agora tunnel serve <name>` now serves an already-created proxy tunnel with `--mode`/`--backend` optional.