### PR TITLE
Hide setup wizard route until backend handlers land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- CHANGE: Redesigned the dashboard with a data-driven network topology, a live activity feed sourced from audit events, a persistent activity rail, and honest degraded/error states.
+
+- CHANGE: Added a tabbed detail drawer surfacing per-session trace lifecycle (proposal through close) and contract-violation detail, including the violation reason inline.
+
+- CHANGE: Added a swimlane activity strip to the Audit screen, visualizing event clusters (sessions, violations, envelopes, tunnels, advertisements, account/environment) on a shared, filter-aware time axis.
+
+- CHANGE: Condensed table density and aligned the dashboard's visual styling with the Customer Connect design system.
+
+- CHANGE: Added dark mode across the UI, with IBM Plex typography and a full design-token system.
+
+- CHANGE: Added a five-step setup wizard at `/setup` (gated off pending backend support).
+
 ## v0.1.5
 
 - FEATURE: Standalone tunnels are now owned by the account rather than by the environment that created them. A tunnel survives retirement of any environment, and any of the owning account's environments may host (serve) it. The new `agora tunnel takeover <name>` command, and `agora tunnel serve --takeover`, reclaim a tunnel by evicting whatever is currently hosting it (deleting its fabric terminators and, for a proxy tunnel, clearing the serve record). Layer 2 session tunnels remain environment-owned.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,8 @@ import Sessions from './screens/Sessions';
 import Setup from './screens/Setup';
 import Workgroups from './screens/Workgroups';
 
+const SETUP_ENABLED = false; // wizard route hidden until backend handlers (workgroups, advertisements, contracts) land
+
 export function App() {
   useEffect(() => {
     const abort = new AbortController();
@@ -51,14 +53,16 @@ const routes: RouteObject[] = [
     ),
   },
   { path: '/login', element: <LoginRoute /> },
-  {
-    path: '/setup',
-    element: (
-      <RequireAuth>
-        <Setup />
-      </RequireAuth>
-    ),
-  },
+  ...(SETUP_ENABLED
+    ? [{
+        path: '/setup',
+        element: (
+          <RequireAuth>
+            <Setup />
+          </RequireAuth>
+        ),
+      }]
+    : []),
   {
     path: '/sessions',
     element: (


### PR DESCRIPTION
The /setup wizard UI merged in #20, but its backend POST handlers (workgroups, advertisements, contracts) aren't implemented yet. Gating the route so users can't reach a non-functional flow. Flip SETUP_ENABLED to true in the PR that adds the handlers.