### PR TITLE
fix: copy-to-clipboard fails in non-secure (http) contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- FIX: Copy-to-clipboard now works when the dashboard is served over http on a non-localhost host (e.g. behind a reverse proxy). Previously the copy buttons failed because the browser Clipboard API is unavailable outside secure contexts; a fallback now handles copying in those cases. Consolidated the previously duplicated copy logic into a single shared helper.
+
 - CHANGE: Redesigned the dashboard with a data-driven network topology, a live activity feed sourced from audit events, a persistent activity rail, and honest degraded/error states.
 
 - CHANGE: Added a tabbed detail drawer surfacing per-session trace lifecycle (proposal through close) and contract-violation detail, including the violation reason inline.

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -1,0 +1,41 @@
+// copyToClipboard writes text to the system clipboard, falling back to a legacy
+// method when the async Clipboard API is unavailable (e.g. non-secure http
+// contexts on a non-localhost host, where navigator.clipboard is undefined).
+// Returns true if either method succeeded, false if both failed. Never throws.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy method below
+  }
+
+  return copyWithExecCommand(text);
+}
+
+function copyWithExecCommand(text: string): boolean {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}

--- a/ui/src/screens/Catalog.tsx
+++ b/ui/src/screens/Catalog.tsx
@@ -46,6 +46,7 @@ import {
   type AdvertisementTunnelMode,
   type Workgroup,
 } from '../lib/api';
+import { copyToClipboard } from '../lib/clipboard';
 
 const routeByTab: Record<string, string> = {
   dashboard: '/',
@@ -430,10 +431,17 @@ function AdvertisementCard({
 }) {
   const gateway = gatewayAccent(advertisement);
   const command = `agora session propose ${advertisement.id}`;
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
 
   function copyCommand() {
-    void navigator.clipboard?.writeText(command);
+    void copyToClipboard(command).then((ok) => {
+      setCopyState(ok ? 'copied' : 'error');
+      setTimeout(() => { setCopyState('idle'); }, 1500);
+    });
   }
+
+  const copyLabel =
+    copyState === 'copied' ? 'Copied' : copyState === 'error' ? 'Copy failed' : 'Propose Session';
 
   const allTags: { label: string; accent: 'contract' | 'workgroup' | 'agora' | 'llm' | 'mcp' }[] = [
     { label: contractName, accent: 'contract' },
@@ -497,7 +505,7 @@ function AdvertisementCard({
           className="mt-2 w-full !justify-start sm:hidden !text-[0.6875rem] gap-1"
         >
           <Send size={11} aria-hidden="true" />
-          Propose Session
+          {copyLabel}
         </Button>
       </div>
 
@@ -512,7 +520,7 @@ function AdvertisementCard({
           className="!text-[0.6875rem] gap-1"
         >
           <Send size={11} aria-hidden="true" />
-          Propose Session
+          {copyLabel}
         </Button>
       </div>
     </article>

--- a/ui/src/screens/Dashboard.tsx
+++ b/ui/src/screens/Dashboard.tsx
@@ -67,6 +67,7 @@ import {
   type DashboardSummaryResponse,
   type DashboardWindow,
 } from '../lib/api';
+import { copyToClipboard } from '../lib/clipboard';
 
 type ActivityWindowOption = {
   value: DashboardWindow;
@@ -465,10 +466,9 @@ function CliAccessModal({ onClose }: { onClose: () => void }) {
   }, []);
 
   const handleCopyConfig = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(CONFIG_COMMAND);
+    if (await copyToClipboard(CONFIG_COMMAND)) {
       flashCopied('config');
-    } catch {
+    } else {
       setError('failed to copy to clipboard');
     }
   }, [flashCopied]);
@@ -485,10 +485,9 @@ function CliAccessModal({ onClose }: { onClose: () => void }) {
   const handleCopyToken = useCallback(async () => {
     const value = await ensureToken();
     if (!value) return;
-    try {
-      await navigator.clipboard.writeText(value);
+    if (await copyToClipboard(value)) {
       flashCopied('token');
-    } catch {
+    } else {
       setError('failed to copy to clipboard');
     }
   }, [ensureToken, flashCopied]);
@@ -496,10 +495,9 @@ function CliAccessModal({ onClose }: { onClose: () => void }) {
   const handleCopyCommand = useCallback(async () => {
     const value = await ensureToken();
     if (!value) return;
-    try {
-      await navigator.clipboard.writeText(`agora enable ${value}`);
+    if (await copyToClipboard(`agora enable ${value}`)) {
       flashCopied('command');
-    } catch {
+    } else {
       setError('failed to copy to clipboard');
     }
   }, [ensureToken, flashCopied]);

--- a/ui/src/screens/Setup.tsx
+++ b/ui/src/screens/Setup.tsx
@@ -48,6 +48,7 @@ import {
   type Workgroup,
   type WorkgroupScope,
 } from '../lib/api';
+import { copyToClipboard } from '../lib/clipboard';
 
 const TOKEN_MASK = '••••••••••••••••••••••••••••••••';
 
@@ -441,10 +442,6 @@ function errorDetail(error: unknown): string {
   return 'request failed';
 }
 
-function copyToClipboard(text: string): Promise<void> {
-  return navigator.clipboard.writeText(text);
-}
-
 // ── Step 1: Organization and Account ──────────────────────────────────────────
 
 const ORG_BLOCK_LINES = [
@@ -462,9 +459,15 @@ function Step1Content({
 }) {
   const [copied1, setCopied1] = useState(false);
   const [copied2, setCopied2] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
 
   function flashCopy(text: string, setFlag: (v: boolean) => void) {
-    void copyToClipboard(text).then(() => {
+    void copyToClipboard(text).then((ok) => {
+      if (!ok) {
+        setCopyError('failed to copy to clipboard');
+        return;
+      }
+      setCopyError(null);
       setFlag(true);
       setTimeout(() => { setFlag(false); }, 1500);
     });
@@ -492,6 +495,7 @@ function Step1Content({
           copied={copied2}
           onCopy={() => { flashCopy(USER_BLOCK_LINES.join('\n'), setCopied2); }}
         />
+        {copyError && <InlineError message={copyError} />}
       </div>
       <label className="flex cursor-pointer items-center gap-3">
         <input
@@ -546,8 +550,13 @@ function Step2Content({
     setTimeout(() => { setCopiedField((c) => (c === field ? null : c)); }, 1500);
   }, []);
 
-  const handleCopyConfig = useCallback(() => {
-    void copyToClipboard(CONFIG_BLOCK_LINES.join('\n')).then(() => { flashCopied('config'); });
+  const handleCopyConfig = useCallback(async () => {
+    if (await copyToClipboard(CONFIG_BLOCK_LINES.join('\n'))) {
+      setTokenError(null);
+      flashCopied('config');
+    } else {
+      setTokenError('failed to copy to clipboard');
+    }
   }, [flashCopied]);
 
   const handleToggleReveal = useCallback(async () => {
@@ -559,15 +568,23 @@ function Step2Content({
   const handleCopyToken = useCallback(async () => {
     const value = await ensureToken();
     if (!value) return;
-    await copyToClipboard(value);
-    flashCopied('token');
+    if (await copyToClipboard(value)) {
+      setTokenError(null);
+      flashCopied('token');
+    } else {
+      setTokenError('failed to copy to clipboard');
+    }
   }, [ensureToken, flashCopied]);
 
   const handleCopyCommand = useCallback(async () => {
     const value = await ensureToken();
     if (!value) return;
-    await copyToClipboard(`agora enable ${value}`);
-    flashCopied('command');
+    if (await copyToClipboard(`agora enable ${value}`)) {
+      setTokenError(null);
+      flashCopied('command');
+    } else {
+      setTokenError('failed to copy to clipboard');
+    }
   }, [ensureToken, flashCopied]);
 
   const tokenDisplay = tokenRevealed && accountToken ? accountToken : TOKEN_MASK;

--- a/ui/src/screens/Workgroups.tsx
+++ b/ui/src/screens/Workgroups.tsx
@@ -55,6 +55,7 @@ import {
   type WorkgroupMembership,
   type WorkgroupMembershipRole,
 } from '../lib/api';
+import { copyToClipboard } from '../lib/clipboard';
 
 type MemberWithWorkgroups = {
   accountId: string;
@@ -1180,10 +1181,16 @@ function WorkgroupDrawer({
   }
 
   const command = `agora workgroup describe ${card.workgroup.id}`;
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
 
   function copyCommand() {
-    void navigator.clipboard?.writeText(command);
+    void copyToClipboard(command).then((ok) => {
+      setCopyState(ok ? 'copied' : 'error');
+      setTimeout(() => { setCopyState('idle'); }, 1500);
+    });
   }
+
+  const copyLabel = copyState === 'copied' ? 'Copied' : copyState === 'error' ? 'Copy failed' : 'Copy';
 
   return (
     <>
@@ -1284,7 +1291,7 @@ function WorkgroupDrawer({
                   onClick={copyCommand}
                 >
                   <Clipboard size={14} aria-hidden="true" />
-                  Copy
+                  {copyLabel}
                 </button>
               </div>
             </SectionPanel>


### PR DESCRIPTION
Consolidate five ad-hoc clipboard call sites into a shared helper (ui/src/lib/clipboard.ts) with a navigator.clipboard -> execCommand fallback. Add focus/setSelectionRange before execCommand so the fallback works over http on non-localhost hosts.

Catalog and Workgroups previously failed silently in non-secure contexts; they now copy via the fallback and surface a visible error if both methods fail.