### PR TITLE
fix: gate all /setup entry points behind SETUP_ENABLED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- FIX: Setup wizard entry points (user-menu button, zero-environment login redirect) are now gated behind the same flag as the /setup route, so nothing links to the route while the wizard is disabled.
+
 - CHANGE: Redesigned the dashboard with a data-driven network topology, a live activity feed sourced from audit events, a persistent activity rail, and honest degraded/error states.
 
 - CHANGE: Added a tabbed detail drawer surfacing per-session trace lifecycle (proposal through close) and contract-violation detail, including the violation reason inline.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate, RouterProvider, useLocation, type RouteO
 
 import { BrandMark } from './components';
 import { getWhoami, setUnauthorizedHandler } from './lib/api';
+import { SETUP_ENABLED } from './lib/config';
 import { clearAuthState, getAuthState, setAuthenticatedAccount, useAuthState } from './lib/auth-state';
 import AuditLog from './screens/AuditLog';
 import Catalog from './screens/Catalog';
@@ -12,8 +13,6 @@ import Login from './screens/Login';
 import Sessions from './screens/Sessions';
 import Setup from './screens/Setup';
 import Workgroups from './screens/Workgroups';
-
-const SETUP_ENABLED = false; // wizard route hidden until backend handlers (workgroups, advertisements, contracts) land
 
 export function App() {
   useEffect(() => {

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -23,6 +23,7 @@ import { StatusPill, type StatusPillStatus } from './StatusPill';
 import { UserBadge } from './UserBadge';
 import { logout } from '../lib/api';
 import { clearAuthState, useAuthState } from '../lib/auth-state';
+import { SETUP_ENABLED } from '../lib/config';
 
 export type AppShellProps = {
   product?: Product;
@@ -165,7 +166,7 @@ export function AppShell({
               isDark={isDark}
               onLogout={handleLogout}
               onToggleDark={toggleDark}
-              onSetupNewOrg={() => { navigate('/setup'); }}
+              onSetupNewOrg={SETUP_ENABLED ? () => navigate('/setup') : undefined}
             />
           </div>
         )}

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -1,3 +1,6 @@
+// wizard route hidden until backend handlers (workgroups, advertisements, contracts) land
+export const SETUP_ENABLED = false;
+
 export type AgoraRuntimeConfig = Readonly<{
   apiBasePath: string;
   version: string;

--- a/ui/src/screens/Login.tsx
+++ b/ui/src/screens/Login.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, LoaderCircle, LogIn } from 'lucide-react';
 import { BrandMark } from '../components';
 import { ApiError, getWhoami, listEnvironments, login } from '../lib/api';
 import { setAuthenticatedAccount } from '../lib/auth-state';
+import { SETUP_ENABLED } from '../lib/config';
 
 export default function Login() {
   const navigate = useNavigate();
@@ -26,7 +27,7 @@ export default function Login() {
       const account = await getWhoami();
       setAuthenticatedAccount(account);
       const environments = await listEnvironments();
-      navigate(environments.length === 0 ? '/setup' : '/', { replace: true });
+      navigate(SETUP_ENABLED && environments.length === 0 ? '/setup' : '/', { replace: true });
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setErrorMessage('Email or password is incorrect.');


### PR DESCRIPTION
Move SETUP_ENABLED to lib/config.ts and import it in App.tsx, AppShell, and Login so the route, the user-menu button, and the zero-environment login redirect all read one flag. When setup is disabled, the button is hidden and the login redirect falls back to the dashboard instead of routing to the dead /setup route.